### PR TITLE
fix FooocusKsampler returning list of images

### DIFF
--- a/py/fooocusNodes.py
+++ b/py/fooocusNodes.py
@@ -765,8 +765,11 @@ class FooocusKsampler:
 
         if image_output == "Hide":
             return {"ui": {"value": list()}, "result": (new_pipe, all_imgs)}
-
-        results["result"] = new_pipe, all_imgs
+        
+        # Combine the processed images back into a single tensor
+        base_image = torch.stack([tensor.squeeze() for tensor in all_imgs])
+        
+        results["result"] = new_pipe, base_image
         return results
 
 


### PR DESCRIPTION
FooocusKsampler returning list of images you cant pass that to most of the comfyui nodes. for example try to upscale that returning image, you will get error. this fix combine the processed images back into a single tensor.