### PR TITLE
let the preKsampler pipe carry additional data

### DIFF
--- a/py/fooocusNodes.py
+++ b/py/fooocusNodes.py
@@ -649,13 +649,20 @@ class FooocusPreKSampler:
 
         log_node_info('Moving model to GPU ...')
         new_pipe = {
+            "image_number": 1,  # should be reseted to one
+            "base_model_name": pipe['base_model_name'],
+            "refiner_model_name": pipe['refiner_model_name'],
+            "optional_lora_stack": pipe['optional_lora_stack'],
+            "use_cn": pipe['use_cn'],
+            "refiner_switch": switch,
+            "positive_prompt": pipe["positive_prompt"],
+            "negative_prompt": pipe["negative_prompt"],
             "tasks": tasks,
             "positive": positive,
             "negative": negative,
             "seed": seed,
             "steps": steps,
             "cfg": cfg_scale,
-            "switch": switch,
             "refiner_swap_method": refiner_swap_method,
             "sampler_name": final_sampler_name,
             "scheduler": final_scheduler_name,


### PR DESCRIPTION
let the preKsampler pipe carry additional data so we may pass it  to a second preKsampler. this will allow us to refine the image from the first Ksampler or generate some variants by lowering the denoise in the second preKsampler denoiser.

![da](https://github.com/Seedsa/Fooocus_Nodes/assets/89942942/c2a932f0-4e34-4796-a824-b8c53b02c949)
note that reset image number is a must other wise the second  ksampler will double the batch size form the first ksampler.
![new](https://github.com/Seedsa/Fooocus_Nodes/assets/89942942/ff9399be-964e-42f0-b62f-f5e6e0b5a202)
