### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "fooocus_nodes"
+description = "This extension provides image generation features based on Fooocus."
+version = "1.0.0"
+license = "LICENSE"
+dependencies = ["torchsde==0.2.5", "einops==0.4.1", "transformers==4.30.2", "safetensors==0.3.1", "accelerate==0.21.0", "pyyaml==6.0", "Pillow==9.2.0", "scipy==1.9.3", "tqdm==4.64.1", "psutil==5.9.5", "pytorch_lightning==1.9.4", "omegaconf==2.2.3", "pygit2==1.12.2", "opencv-contrib-python==4.8.0.74", "httpx==0.24.1", "onnxruntime==1.16.3", "timm==0.9.2"]
+
+[project.urls]
+Repository = "https://github.com/Seedsa/Fooocus_Nodes"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "Fooocus_Nodes"
+Icon = ""


### PR DESCRIPTION
We are working with dr.lt.data and comfyanon to build a global registry for custom nodes (similar to PyPI). Eventually, the registry will be used as a backend for the UI-manager. All nodes go through a verification process before being published to users.

The main benefits are that authors can
- publish nodes by version and users can safely update nodes knowing ahead of time if their workflows will break or not
- automate testing against new commits in the comfy repo and existing workflows through our CI/CD dashboard

Action Required:

- [ ] Go to the [registry](https://registry.comfy.org). Login and create a publisher id. Add the publisher id into the pyproject.toml file.
- [ ] Write a short description.
- [ ] Merge the separate Github Actions PR and run the workflow.

If you want to publish the node manually, [install the cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) and run `comfy node publish`

Check out our [docs](https://docs.comfy.org/registry/overview#introduction) if you want to know more about the registry. Otherwise, feel free to message me on discord at haohao_81202 or join our [server](https://discord.com/invite/comfyorg) if you have any questions!