### PR TITLE
[WIP] Update ModelPatcher to work with changes in ComfyUI v0.3.7 onwards

### DIFF
--- a/py/extras/expansion.py
+++ b/py/extras/expansion.py
@@ -13,7 +13,7 @@ import comfy.model_management as model_management
 from transformers.generation.logits_process import LogitsProcessorList
 from transformers import AutoTokenizer, AutoModelForCausalLM, set_seed
 from modules.config import path_fooocus_expansion
-from ldm_patched.modules.model_patcher import ModelPatcher
+from ldm_patched.modules.model_patcher import FooocusModelPatcher
 
 
 # limitation of np.random.seed(), called from transformers.set_seed()
@@ -75,7 +75,7 @@ class FooocusExpansion:
         if use_fp16:
             self.model.half()
 
-        self.patcher = ModelPatcher(self.model, load_device=load_device, offload_device=offload_device)
+        self.patcher = FooocusModelPatcher(self.model, load_device=load_device, offload_device=offload_device)
         print(f'Fooocus Expansion engine loaded for {load_device}, use_fp16 = {use_fp16}.')
 
     @torch.no_grad()

--- a/py/extras/interrogate.py
+++ b/py/extras/interrogate.py
@@ -5,7 +5,7 @@ import comfy.model_management as model_management
 from torchvision import transforms
 from torchvision.transforms.functional import InterpolationMode
 from modules.model_loader import load_file_from_url
-from ldm_patched.modules.model_patcher import ModelPatcher
+from ldm_patched.modules.model_patcher import FooocusModelPatcher
 from extras.BLIP.models.blip import blip_decoder
 
 
@@ -44,7 +44,7 @@ class Interrogator:
                 model.half()
                 self.dtype = torch.float16
 
-            self.blip_model = ModelPatcher(model, load_device=self.load_device, offload_device=self.offload_device)
+            self.blip_model = FooocusModelPatcher(model, load_device=self.load_device, offload_device=self.offload_device)
 
         model_management.load_model_gpu(self.blip_model)
 

--- a/py/extras/ip_adapter.py
+++ b/py/extras/ip_adapter.py
@@ -5,7 +5,7 @@ import comfy.model_management as model_management
 import ldm_patched.ldm.modules.attention as attention
 
 from extras.resampler import Resampler
-from ldm_patched.modules.model_patcher import ModelPatcher
+from ldm_patched.modules.model_patcher import FooocusModelPatcher
 from modules.core import numpy_to_pytorch
 from modules.ops import use_patched_ops
 from ldm_patched.modules.ops import manual_cast
@@ -133,9 +133,9 @@ def load_ip_adapter(clip_vision_path, ip_negative_path, ip_adapter_path):
     ip_adapter.dtype = torch.float16 if use_fp16 else torch.float32
     ip_adapter.to(offload_device, dtype=ip_adapter.dtype)
 
-    image_proj_model = ModelPatcher(model=ip_adapter.image_proj_model, load_device=load_device,
+    image_proj_model = FooocusModelPatcher(model=ip_adapter.image_proj_model, load_device=load_device,
                                     offload_device=offload_device)
-    ip_layers = ModelPatcher(model=ip_adapter.ip_layers, load_device=load_device,
+    ip_layers = FooocusModelPatcher(model=ip_adapter.ip_layers, load_device=load_device,
                              offload_device=offload_device)
 
     ip_adapters[ip_adapter_path] = dict(

--- a/py/extras/vae_interpose.py
+++ b/py/extras/vae_interpose.py
@@ -6,7 +6,7 @@ import safetensors.torch as sf
 import torch.nn as nn
 import comfy.model_management
 
-from ldm_patched.modules.model_patcher import ModelPatcher
+from ldm_patched.modules.model_patcher import FooocusModelPatcher
 import folder_paths
 
 class Block(nn.Module):
@@ -78,7 +78,7 @@ def parse(x):
         fp16 = comfy.model_management.should_use_fp16()
         if fp16:
             model = model.half()
-        vae_approx_model = ModelPatcher(
+        vae_approx_model = FooocusModelPatcher(
             model=model,
             load_device=comfy.model_management.get_torch_device(),
             offload_device=torch.device('cpu')

--- a/py/ldm_patched/modules/clip_vision.py
+++ b/py/ldm_patched/modules/clip_vision.py
@@ -39,7 +39,7 @@ class ClipVisionModel():
         self.model = ldm_patched.modules.clip_model.CLIPVisionModelProjection(config, self.dtype, offload_device, ldm_patched.modules.ops.manual_cast)
         self.model.eval()
 
-        self.patcher = ldm_patched.modules.model_patcher.ModelPatcher(self.model, load_device=self.load_device, offload_device=offload_device)
+        self.patcher = ldm_patched.modules.model_patcher.FooocusModelPatcher(self.model, load_device=self.load_device, offload_device=offload_device)
 
     def load_sd(self, sd):
         return self.model.load_state_dict(sd, strict=False)

--- a/py/ldm_patched/modules/controlnet.py
+++ b/py/ldm_patched/modules/controlnet.py
@@ -136,7 +136,7 @@ class ControlNet(ControlBase):
         super().__init__(device)
         self.control_model = control_model
         self.load_device = load_device
-        self.control_model_wrapped = ldm_patched.modules.model_patcher.ModelPatcher(self.control_model, load_device=load_device, offload_device=comfy.model_management.unet_offload_device())
+        self.control_model_wrapped = ldm_patched.modules.model_patcher.FooocusModelPatcher(self.control_model, load_device=load_device, offload_device=comfy.model_management.unet_offload_device())
         self.global_average_pooling = global_average_pooling
         self.model_sampling_current = None
         self.manual_cast_dtype = manual_cast_dtype

--- a/py/ldm_patched/modules/latent_formats.py
+++ b/py/ldm_patched/modules/latent_formats.py
@@ -2,7 +2,9 @@
 class LatentFormat:
     scale_factor = 1.0
     latent_channels = 4
+    latent_dimensions = 2
     latent_rgb_factors = None
+    latent_rgb_factors_bias = None
     taesd_decoder_name = None
 
     def process_in(self, latent):
@@ -24,17 +26,26 @@ class SD15(LatentFormat):
         self.taesd_decoder_name = "taesd_decoder"
 
 class SDXL(LatentFormat):
+    scale_factor = 0.13025
+
     def __init__(self):
-        self.scale_factor = 0.13025
         self.latent_rgb_factors = [
                     #   R        G        B
-                    [ 0.3920,  0.4054,  0.4549],
-                    [-0.2634, -0.0196,  0.0653],
-                    [ 0.0568,  0.1687, -0.0755],
-                    [-0.3112, -0.2359, -0.2076]
+                    [ 0.3651,  0.4232,  0.4341],
+                    [-0.2533, -0.0042,  0.1068],
+                    [ 0.1076,  0.1111, -0.0362],
+                    [-0.3165, -0.2492, -0.2188]
                 ]
+        self.latent_rgb_factors_bias = [ 0.1084, -0.0175, -0.0011]
+
         self.taesd_decoder_name = "taesdxl_decoder"
 
 class SD_X4(LatentFormat):
     def __init__(self):
         self.scale_factor = 0.08333
+        self.latent_rgb_factors = [
+            [-0.2340, -0.3863, -0.3257],
+            [ 0.0994,  0.0885, -0.0908],
+            [-0.2833, -0.2349, -0.3741],
+            [ 0.2523, -0.0055, -0.1651]
+        ]

--- a/py/ldm_patched/modules/model_base.py
+++ b/py/ldm_patched/modules/model_base.py
@@ -7,12 +7,14 @@ import ldm_patched.modules.conds
 import ldm_patched.modules.ops
 from enum import Enum
 from . import utils
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from comfy.model_patcher import ModelPatcher
 
 class ModelType(Enum):
     EPS = 1
     V_PREDICTION = 2
     V_PREDICTION_EDM = 3
-
 
 from ldm_patched.modules.model_sampling import EPS, V_PREDICTION, ModelSamplingDiscrete, ModelSamplingContinuousEDM
 
@@ -42,6 +44,7 @@ class BaseModel(torch.nn.Module):
         self.latent_format = model_config.latent_format
         self.model_config = model_config
         self.manual_cast_dtype = model_config.manual_cast_dtype
+        self.current_patcher: 'ModelPatcher' = None
 
         if not unet_config.get("disable_unet_model_creation", False):
             if self.manual_cast_dtype is not None:

--- a/py/ldm_patched/modules/model_patcher.py
+++ b/py/ldm_patched/modules/model_patcher.py
@@ -15,7 +15,8 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
-
+from __future__ import annotations
+from typing import Optional, Callable
 import torch
 import copy
 import inspect
@@ -28,64 +29,15 @@ import comfy.utils
 import comfy.float
 import comfy.model_management
 import comfy.lora
+import comfy.hooks
+from comfy.model_patcher import ModelPatcher, wipe_lowvram_weight
+import comfy.patcher_extension
+from comfy.patcher_extension import CallbacksMP, WrappersMP, PatcherInjection
+
 try:
     from comfy.comfy_types import UnetWrapperFunction
 except Exception:
     from comfy.types import UnetWrapperFunction
-
-
-def string_to_seed(data):
-    crc = 0xFFFFFFFF
-    for byte in data:
-        if isinstance(byte, str):
-            byte = ord(byte)
-        crc ^= byte
-        for _ in range(8):
-            if crc & 1:
-                crc = (crc >> 1) ^ 0xEDB88320
-            else:
-                crc >>= 1
-    return crc ^ 0xFFFFFFFF
-
-def set_model_options_patch_replace(model_options, patch, name, block_name, number, transformer_index=None):
-    to = model_options["transformer_options"].copy()
-
-    if "patches_replace" not in to:
-        to["patches_replace"] = {}
-    else:
-        to["patches_replace"] = to["patches_replace"].copy()
-
-    if name not in to["patches_replace"]:
-        to["patches_replace"][name] = {}
-    else:
-        to["patches_replace"][name] = to["patches_replace"][name].copy()
-
-    if transformer_index is not None:
-        block = (block_name, number, transformer_index)
-    else:
-        block = (block_name, number)
-    to["patches_replace"][name][block] = patch
-    model_options["transformer_options"] = to
-    return model_options
-
-def set_model_options_post_cfg_function(model_options, post_cfg_function, disable_cfg1_optimization=False):
-    model_options["sampler_post_cfg_function"] = model_options.get("sampler_post_cfg_function", []) + [post_cfg_function]
-    if disable_cfg1_optimization:
-        model_options["disable_cfg1_optimization"] = True
-    return model_options
-
-def set_model_options_pre_cfg_function(model_options, pre_cfg_function, disable_cfg1_optimization=False):
-    model_options["sampler_pre_cfg_function"] = model_options.get("sampler_pre_cfg_function", []) + [pre_cfg_function]
-    if disable_cfg1_optimization:
-        model_options["disable_cfg1_optimization"] = True
-    return model_options
-
-def wipe_lowvram_weight(m):
-    if hasattr(m, "prev_comfy_cast_weights"):
-        m.comfy_cast_weights = m.prev_comfy_cast_weights
-        del m.prev_comfy_cast_weights
-    m.weight_function = None
-    m.bias_function = None
 
 class LowVramPatch:
     def __init__(self, key, patches):
@@ -94,345 +46,105 @@ class LowVramPatch:
     def __call__(self, weight):
         return comfy.lora.calculate_weight(self.patches[self.key], weight, self.key, intermediate_dtype=weight.dtype)
 
-class ModelPatcher:
+class FooocusModelPatcher(ModelPatcher):
     def __init__(self, model, load_device, offload_device, size=0, weight_inplace_update=False):
-        self.size = size
-        self.model = model
-        if not hasattr(self.model, 'device'):
-            logging.debug("Model doesn't have a device attribute.")
-            self.model.device = offload_device
-        elif self.model.device is None:
-            self.model.device = offload_device
-
-        self.patches = {}
-        self.backup = {}
-        self.object_patches = {}
-        self.object_patches_backup = {}
-        self.model_options = {"transformer_options":{}}
-        self.model_size()
-        self.load_device = load_device
-        self.offload_device = offload_device
-        self.weight_inplace_update = weight_inplace_update
-        self.patches_uuid = uuid.uuid4()
-
-        if not hasattr(self.model, 'model_loaded_weight_memory'):
-            self.model.model_loaded_weight_memory = 0
-
-        if not hasattr(self.model, 'lowvram_patch_counter'):
-            self.model.lowvram_patch_counter = 0
-
-        if not hasattr(self.model, 'model_lowvram'):
-            self.model.model_lowvram = False
-
-    def model_size(self):
-        if self.size > 0:
-            return self.size
-        self.size = comfy.model_management.module_size(self.model)
-        return self.size
-
-    def loaded_size(self):
-        return self.model.model_loaded_weight_memory
-
-    def lowvram_patch_counter(self):
-        return self.model.lowvram_patch_counter
-
-    def clone(self):
-        n = ModelPatcher(self.model, self.load_device, self.offload_device, self.size, weight_inplace_update=self.weight_inplace_update)
-        n.patches = {}
-        for k in self.patches:
-            n.patches[k] = self.patches[k][:]
-        n.patches_uuid = self.patches_uuid
-
-        n.object_patches = self.object_patches.copy()
-        n.model_options = copy.deepcopy(self.model_options)
-        n.backup = self.backup
-        n.object_patches_backup = self.object_patches_backup
-        return n
-
-    def is_clone(self, other):
-        if hasattr(other, 'model') and self.model is other.model:
-            return True
-        return False
-
-    def clone_has_same_weights(self, clone):
-        if not self.is_clone(clone):
-            return False
-
-        if len(self.patches) == 0 and len(clone.patches) == 0:
-            return True
-
-        if self.patches_uuid == clone.patches_uuid:
-            if len(self.patches) != len(clone.patches):
-                logging.warning("WARNING: something went wrong, same patch uuid but different length of patches.")
-            else:
-                return True
-
-    def memory_required(self, input_shape):
-        return self.model.memory_required(input_shape=input_shape)
-
-    def set_model_sampler_cfg_function(self, sampler_cfg_function, disable_cfg1_optimization=False):
-        if len(inspect.signature(sampler_cfg_function).parameters) == 3:
-            self.model_options["sampler_cfg_function"] = lambda args: sampler_cfg_function(args["cond"], args["uncond"], args["cond_scale"]) #Old way
-        else:
-            self.model_options["sampler_cfg_function"] = sampler_cfg_function
-        if disable_cfg1_optimization:
-            self.model_options["disable_cfg1_optimization"] = True
-
-    def set_model_sampler_post_cfg_function(self, post_cfg_function, disable_cfg1_optimization=False):
-        self.model_options = set_model_options_post_cfg_function(self.model_options, post_cfg_function, disable_cfg1_optimization)
-
-    def set_model_sampler_pre_cfg_function(self, pre_cfg_function, disable_cfg1_optimization=False):
-        self.model_options = set_model_options_pre_cfg_function(self.model_options, pre_cfg_function, disable_cfg1_optimization)
-
-    def set_model_unet_function_wrapper(self, unet_wrapper_function: UnetWrapperFunction):
-        self.model_options["model_function_wrapper"] = unet_wrapper_function
-
-    def set_model_denoise_mask_function(self, denoise_mask_function):
-        self.model_options["denoise_mask_function"] = denoise_mask_function
-
-    def set_model_patch(self, patch, name):
-        to = self.model_options["transformer_options"]
-        if "patches" not in to:
-            to["patches"] = {}
-        to["patches"][name] = to["patches"].get(name, []) + [patch]
-
-    def set_model_patch_replace(self, patch, name, block_name, number, transformer_index=None):
-        self.model_options = set_model_options_patch_replace(self.model_options, patch, name, block_name, number, transformer_index=transformer_index)
-
-    def set_model_attn1_patch(self, patch):
-        self.set_model_patch(patch, "attn1_patch")
-
-    def set_model_attn2_patch(self, patch):
-        self.set_model_patch(patch, "attn2_patch")
-
-    def set_model_attn1_replace(self, patch, block_name, number, transformer_index=None):
-        self.set_model_patch_replace(patch, "attn1", block_name, number, transformer_index)
-
-    def set_model_attn2_replace(self, patch, block_name, number, transformer_index=None):
-        self.set_model_patch_replace(patch, "attn2", block_name, number, transformer_index)
-
-    def set_model_attn1_output_patch(self, patch):
-        self.set_model_patch(patch, "attn1_output_patch")
-
-    def set_model_attn2_output_patch(self, patch):
-        self.set_model_patch(patch, "attn2_output_patch")
-
-    def set_model_input_block_patch(self, patch):
-        self.set_model_patch(patch, "input_block_patch")
-
-    def set_model_input_block_patch_after_skip(self, patch):
-        self.set_model_patch(patch, "input_block_patch_after_skip")
-
-    def set_model_output_block_patch(self, patch):
-        self.set_model_patch(patch, "output_block_patch")
-
-    def add_object_patch(self, name, obj):
-        self.object_patches[name] = obj
-
-    def get_model_object(self, name):
-        if name in self.object_patches:
-            return self.object_patches[name]
-        else:
-            if name in self.object_patches_backup:
-                return self.object_patches_backup[name]
-            else:
-                return comfy.utils.get_attr(self.model, name)
-
-    def model_patches_to(self, device):
-        to = self.model_options["transformer_options"]
-        if "patches" in to:
-            patches = to["patches"]
-            for name in patches:
-                patch_list = patches[name]
-                for i in range(len(patch_list)):
-                    if hasattr(patch_list[i], "to"):
-                        patch_list[i] = patch_list[i].to(device)
-        if "patches_replace" in to:
-            patches = to["patches_replace"]
-            for name in patches:
-                patch_list = patches[name]
-                for k in patch_list:
-                    if hasattr(patch_list[k], "to"):
-                        patch_list[k] = patch_list[k].to(device)
-        if "model_function_wrapper" in self.model_options:
-            wrap_func = self.model_options["model_function_wrapper"]
-            if hasattr(wrap_func, "to"):
-                self.model_options["model_function_wrapper"] = wrap_func.to(device)
-
-    def model_dtype(self):
-        if hasattr(self.model, "get_dtype"):
-            return self.model.get_dtype()
-
-    def add_patches(self, patches, strength_patch=1.0, strength_model=1.0):
-        p = set()
-        model_sd = self.model.state_dict()
-        for k in patches:
-            offset = None
-            function = None
-            if isinstance(k, str):
-                key = k
-            else:
-                offset = k[1]
-                key = k[0]
-                if len(k) > 2:
-                    function = k[2]
-
-            if key in model_sd:
-                p.add(k)
-                current_patches = self.patches.get(key, [])
-                current_patches.append((strength_patch, patches[k], strength_model, offset, function))
-                self.patches[key] = current_patches
-
-        self.patches_uuid = uuid.uuid4()
-        return list(p)
-
-    def get_key_patches(self, filter_prefix=None):
-        comfy.model_management.unload_model_clones(self)
-        model_sd = self.model_state_dict()
-        p = {}
-        for k in model_sd:
-            if filter_prefix is not None:
-                if not k.startswith(filter_prefix):
-                    continue
-            if k in self.patches:
-                p[k] = [model_sd[k]] + self.patches[k]
-            else:
-                p[k] = (model_sd[k],)
-        return p
-
-    def model_state_dict(self, filter_prefix=None):
-        sd = self.model.state_dict()
-        keys = list(sd.keys())
-        if filter_prefix is not None:
-            for k in keys:
-                if not k.startswith(filter_prefix):
-                    sd.pop(k)
-        return sd
-
-    def patch_weight_to_device(self, key, device_to=None, inplace_update=False):
-        if key not in self.patches:
-            return
-
-        weight = comfy.utils.get_attr(self.model, key)
-
-        inplace_update = self.weight_inplace_update or inplace_update
-
-        if key not in self.backup:
-            self.backup[key] = collections.namedtuple('Dimension', ['weight', 'inplace_update'])(weight.to(device=self.offload_device, copy=inplace_update), inplace_update)
-
-        if device_to is not None:
-            temp_weight = comfy.model_management.cast_to_device(weight, device_to, torch.float32, copy=True)
-        else:
-            temp_weight = weight.to(torch.float32, copy=True)
-        out_weight = comfy.lora.calculate_weight(self.patches[key], temp_weight, key)
-        out_weight = comfy.float.stochastic_rounding(out_weight, weight.dtype, seed=string_to_seed(key))
-        if inplace_update:
-            comfy.utils.copy_to_param(self.model, key, out_weight)
-        else:
-            comfy.utils.set_attr_param(self.model, key, out_weight)
+        super().__init__(model, load_device, offload_device, size, weight_inplace_update)
 
     def load(self, device_to=None, lowvram_model_memory=0, force_patch_weights=False, full_load=False):
-        mem_counter = 0
-        patch_counter = 0
-        lowvram_counter = 0
-        loading = []
-        for n, m in self.model.named_modules():
-            if hasattr(m, "comfy_cast_weights") or hasattr(m, "weight"):
-                loading.append((comfy.model_management.module_size(m), n, m))
+        with self.use_ejected():
+            self.unpatch_hooks()
+            mem_counter = 0
+            patch_counter = 0
+            lowvram_counter = 0
+            loading = self._load_list()
 
-        load_completely = []
-        loading.sort(reverse=True)
-        for x in loading:
-            n = x[1]
-            m = x[2]
-            module_mem = x[0]
+            load_completely = []
+            loading.sort(reverse=True)
+            for x in loading:
+                n = x[1]
+                m = x[2]
+                params = x[3]
+                module_mem = x[0]
 
-            lowvram_weight = False
+                lowvram_weight = False
 
-            if not full_load and hasattr(m, "comfy_cast_weights"):
-                if mem_counter + module_mem >= lowvram_model_memory:
-                    lowvram_weight = True
-                    lowvram_counter += 1
-                    if hasattr(m, "prev_comfy_cast_weights"): #Already lowvramed
+                if not full_load and hasattr(m, "comfy_cast_weights"):
+                    if mem_counter + module_mem >= lowvram_model_memory:
+                        lowvram_weight = True
+                        lowvram_counter += 1
+                        if hasattr(m, "prev_comfy_cast_weights"): #Already lowvramed
+                            continue
+
+                weight_key = "{}.weight".format(n)
+                bias_key = "{}.bias".format(n)
+
+                if lowvram_weight:
+                    if weight_key in self.patches:
+                        if force_patch_weights:
+                            self.patch_weight_to_device(weight_key)
+                        else:
+                            m.weight_function = LowVramPatch(weight_key, self.patches)
+                            patch_counter += 1
+                    if bias_key in self.patches:
+                        if force_patch_weights:
+                            self.patch_weight_to_device(bias_key)
+                        else:
+                            m.bias_function = LowVramPatch(bias_key, self.patches)
+                            patch_counter += 1
+
+                    m.prev_comfy_cast_weights = m.comfy_cast_weights
+                    m.comfy_cast_weights = True
+                else:
+                    if hasattr(m, "comfy_cast_weights"):
+                        if m.comfy_cast_weights:
+                            wipe_lowvram_weight(m)
+
+                    if full_load or mem_counter + module_mem < lowvram_model_memory:
+                        mem_counter += module_mem
+                        load_completely.append((module_mem, n, m, params))
+
+            load_completely.sort(reverse=True)
+            for x in load_completely:
+                n = x[1]
+                m = x[2]
+                params = x[3]
+                if hasattr(m, "comfy_patched_weights"):
+                    if m.comfy_patched_weights == True:
                         continue
 
-            weight_key = "{}.weight".format(n)
-            bias_key = "{}.bias".format(n)
+                for param in params:
+                    self.patch_weight_to_device("{}.{}".format(n, param), device_to=device_to)
 
-            if lowvram_weight:
-                if weight_key in self.patches:
-                    if force_patch_weights:
-                        self.patch_weight_to_device(weight_key)
-                    else:
-                        m.weight_function = LowVramPatch(weight_key, self.patches)
-                        patch_counter += 1
-                if bias_key in self.patches:
-                    if force_patch_weights:
-                        self.patch_weight_to_device(bias_key)
-                    else:
-                        m.bias_function = LowVramPatch(bias_key, self.patches)
-                        patch_counter += 1
+                logging.debug("lowvram: loaded module regularly {} {}".format(n, m))
+                m.comfy_patched_weights = True
 
-                m.prev_comfy_cast_weights = m.comfy_cast_weights
-                m.comfy_cast_weights = True
+            for x in load_completely:
+                x[2].to(device_to)
+
+            if lowvram_counter > 0:
+                logging.info("loaded partially {} {} {}".format(lowvram_model_memory / (1024 * 1024), mem_counter / (1024 * 1024), patch_counter))
+                self.model.model_lowvram = True
             else:
-                if hasattr(m, "comfy_cast_weights"):
-                    if m.comfy_cast_weights:
-                        wipe_lowvram_weight(m)
+                logging.info("loaded completely {} {} {}".format(lowvram_model_memory / (1024 * 1024), mem_counter / (1024 * 1024), full_load))
+                self.model.model_lowvram = False
+                if full_load:
+                    self.model.to(device_to)
+                    mem_counter = self.model_size()
 
-                if hasattr(m, "weight"):
-                    mem_counter += module_mem
-                    load_completely.append((module_mem, n, m))
+            self.model.lowvram_patch_counter += patch_counter
+            # self.model.device = device_to
+            self.model.model_loaded_weight_memory = mem_counter
+            self.model.current_weight_patches_uuid = self.patches_uuid
 
-        load_completely.sort(reverse=True)
-        for x in load_completely:
-            n = x[1]
-            m = x[2]
-            weight_key = "{}.weight".format(n)
-            bias_key = "{}.bias".format(n)
-            if hasattr(m, "comfy_patched_weights"):
-                if m.comfy_patched_weights == True:
-                    continue
+            for callback in self.get_all_callbacks(CallbacksMP.ON_LOAD):
+                callback(self, device_to, lowvram_model_memory, force_patch_weights, full_load)
 
-            self.patch_weight_to_device(weight_key, device_to=device_to)
-            self.patch_weight_to_device(bias_key, device_to=device_to)
-            logging.debug("lowvram: loaded module regularly {} {}".format(n, m))
-            m.comfy_patched_weights = True
-
-        for x in load_completely:
-            x[2].to(device_to)
-
-        if lowvram_counter > 0:
-            logging.info("loaded partially {} {} {}".format(lowvram_model_memory / (1024 * 1024), mem_counter / (1024 * 1024), patch_counter))
-            self.model.model_lowvram = True
-        else:
-            logging.info("loaded completely {} {} {}".format(lowvram_model_memory / (1024 * 1024), mem_counter / (1024 * 1024), full_load))
-            self.model.model_lowvram = False
-            if full_load:
-                self.model.to(device_to)
-                mem_counter = self.model_size()
-
-        self.model.lowvram_patch_counter += patch_counter
-        # self.model.device = device_to
-        self.model.model_loaded_weight_memory = mem_counter
-
-    def patch_model(self, device_to=None, lowvram_model_memory=0, load_weights=True, force_patch_weights=False):
-        for k in self.object_patches:
-            old = comfy.utils.set_attr(self.model, k, self.object_patches[k])
-            if k not in self.object_patches_backup:
-                self.object_patches_backup[k] = old
-
-        if lowvram_model_memory == 0:
-            full_load = True
-        else:
-            full_load = False
-
-        if load_weights:
-            self.load(device_to, lowvram_model_memory=lowvram_model_memory, force_patch_weights=force_patch_weights, full_load=full_load)
-        return self.model
+            self.apply_hooks(self.forced_hooks, force_apply=True)
 
     def unpatch_model(self, device_to=None, unpatch_weights=True):
+        self.eject_model()
         if unpatch_weights:
+            self.unpatch_hooks()
             if self.model.model_lowvram:
                 for m in self.model.modules():
                     wipe_lowvram_weight(m)
@@ -449,6 +161,7 @@ class ModelPatcher:
                 else:
                     comfy.utils.set_attr_param(self.model, k, bk.weight)
 
+            self.model.current_weight_patches_uuid = None
             self.backup.clear()
 
             if device_to is not None:
@@ -465,72 +178,3 @@ class ModelPatcher:
             comfy.utils.set_attr(self.model, k, self.object_patches_backup[k])
 
         self.object_patches_backup.clear()
-
-    def partially_unload(self, device_to, memory_to_free=0):
-        memory_freed = 0
-        patch_counter = 0
-        unload_list = []
-
-        for n, m in self.model.named_modules():
-            shift_lowvram = False
-            if hasattr(m, "comfy_cast_weights"):
-                module_mem = comfy.model_management.module_size(m)
-                unload_list.append((module_mem, n, m))
-
-        unload_list.sort()
-        for unload in unload_list:
-            if memory_to_free < memory_freed:
-                break
-            module_mem = unload[0]
-            n = unload[1]
-            m = unload[2]
-            weight_key = "{}.weight".format(n)
-            bias_key = "{}.bias".format(n)
-
-            if hasattr(m, "comfy_patched_weights") and m.comfy_patched_weights == True:
-                for key in [weight_key, bias_key]:
-                    bk = self.backup.get(key, None)
-                    if bk is not None:
-                        if bk.inplace_update:
-                            comfy.utils.copy_to_param(self.model, key, bk.weight)
-                        else:
-                            comfy.utils.set_attr_param(self.model, key, bk.weight)
-                        self.backup.pop(key)
-
-                m.to(device_to)
-                if weight_key in self.patches:
-                    m.weight_function = LowVramPatch(weight_key, self.patches)
-                    patch_counter += 1
-                if bias_key in self.patches:
-                    m.bias_function = LowVramPatch(bias_key, self.patches)
-                    patch_counter += 1
-
-                m.prev_comfy_cast_weights = m.comfy_cast_weights
-                m.comfy_cast_weights = True
-                m.comfy_patched_weights = False
-                memory_freed += module_mem
-                logging.debug("freed {}".format(n))
-
-        self.model.model_lowvram = True
-        self.model.lowvram_patch_counter += patch_counter
-        self.model.model_loaded_weight_memory -= memory_freed
-        return memory_freed
-
-    def partially_load(self, device_to, extra_memory=0):
-        self.unpatch_model(unpatch_weights=False)
-        self.patch_model(load_weights=False)
-        full_load = False
-        if self.model.model_lowvram == False:
-            return 0
-        if self.model.model_loaded_weight_memory + extra_memory > self.model_size():
-            full_load = True
-        current_used = self.model.model_loaded_weight_memory
-        self.load(device_to, lowvram_model_memory=current_used + extra_memory, full_load=full_load)
-        return self.model.model_loaded_weight_memory - current_used
-
-    def current_loaded_device(self):
-        return self.model.device
-
-    def calculate_weight(self, patches, weight, key, intermediate_dtype=torch.float32):
-        print("WARNING the ModelPatcher.calculate_weight function is deprecated, please use: comfy.lora.calculate_weight instead")
-        return comfy.lora.calculate_weight(patches, weight, key, intermediate_dtype=intermediate_dtype)

--- a/py/modules/patch.py
+++ b/py/modules/patch.py
@@ -606,7 +606,7 @@ def patch_all():
     patch_all_precision()
     patch_all_clip()
     comfy.lora.calculate_weight = calculate_weight_patched
-    # ldm_patched.modules.model_patcher.ModelPatcher.calculate_weight = calculate_weight_patched
+    # ldm_patched.modules.model_patcher.FooocusModelPatcher.calculate_weight = calculate_weight_patched
     ldm_patched.controlnet.cldm.ControlNet.forward = patched_cldm_forward
     ldm_patched.ldm.modules.diffusionmodules.openaimodel.UNetModel.forward = patched_unet_forward
     ldm_patched.modules.model_base.SDXL.encode_adm = sdxl_encode_adm_patched

--- a/py/modules/patch_clip.py
+++ b/py/modules/patch_clip.py
@@ -162,7 +162,7 @@ def patched_ClipVisionModel__init__(self, json_config):
             self.model = CLIPVisionModelWithProjection(config)
 
     self.model.to(self.dtype)
-    self.patcher = ldm_patched.modules.model_patcher.ModelPatcher(
+    self.patcher = ldm_patched.modules.model_patcher.FooocusModelPatcher(
         self.model,
         load_device=self.load_device,
         offload_device=self.offload_device

--- a/workflow/upscale.json
+++ b/workflow/upscale.json
@@ -1,0 +1,451 @@
+{
+  "last_node_id": 13,
+  "last_link_id": 16,
+  "nodes": [
+    {
+      "id": 5,
+      "type": "Fooocus Styles",
+      "pos": [
+        297,
+        494
+      ],
+      "size": [
+        425,
+        500
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [],
+      "outputs": [
+        {
+          "name": "fooocus_styles",
+          "type": "FOOOCUS_STYLES",
+          "links": [
+            3
+          ],
+          "slot_index": 0,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Fooocus Styles",
+        "values": [
+          "Fooocus V2",
+          "Fooocus Enhance",
+          "Fooocus Sharp"
+        ]
+      },
+      "widgets_values": [
+        "fooocus_styles",
+        "Fooocus V2,Fooocus Enhance,Fooocus Sharp"
+      ]
+    },
+    {
+      "id": 11,
+      "type": "Fooocus LoraStack",
+      "pos": [
+        -163,
+        141
+      ],
+      "size": [
+        380.4000244140625,
+        130
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "optional_lora_stack",
+          "type": "LORA_STACK",
+          "link": null,
+          "shape": 7
+        }
+      ],
+      "outputs": [
+        {
+          "name": "lora_stack",
+          "type": "LORA_STACK",
+          "links": [
+            12
+          ],
+          "slot_index": 0,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Fooocus LoraStack"
+      },
+      "widgets_values": [
+        true,
+        1,
+        "None",
+        1,
+        "None",
+        1,
+        "None",
+        1,
+        "None",
+        1,
+        "None",
+        1,
+        "None",
+        1,
+        "None",
+        1,
+        "None",
+        1,
+        "None",
+        1,
+        "None",
+        1
+      ]
+    },
+    {
+      "id": 12,
+      "type": "Fooocus Loader",
+      "pos": [
+        303,
+        96
+      ],
+      "size": [
+        400,
+        294
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "optional_lora_stack",
+          "type": "LORA_STACK",
+          "link": 12,
+          "shape": 7
+        }
+      ],
+      "outputs": [
+        {
+          "name": "pipe",
+          "type": "PIPE_LINE",
+          "links": [
+            13
+          ],
+          "slot_index": 0,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Fooocus Loader"
+      },
+      "widgets_values": [
+        "juggernautXL_v8Rundiffusion.safetensors",
+        "Baked VAE",
+        "None",
+        0.5,
+        "joint",
+        2,
+        "",
+        "",
+        "1024 x 1024",
+        1024,
+        1024,
+        1
+      ]
+    },
+    {
+      "id": 13,
+      "type": "Fooocus Upscale",
+      "pos": [
+        1750.9818115234375,
+        142.5360107421875
+      ],
+      "size": [
+        315,
+        386
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "pipe",
+          "type": "PIPE_LINE",
+          "link": 15
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 16,
+          "shape": 7
+        }
+      ],
+      "outputs": [
+        {
+          "name": "pipe",
+          "type": "PIPE_LINE",
+          "links": null
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "links": null
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Fooocus Upscale"
+      },
+      "widgets_values": [
+        2,
+        18,
+        0.382,
+        false,
+        "Preview",
+        "ComfyUI"
+      ]
+    },
+    {
+      "id": 4,
+      "type": "Fooocus KSampler",
+      "pos": [
+        1352.365966796875,
+        153.59494018554688
+      ],
+      "size": [
+        315,
+        290
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "pipe",
+          "type": "PIPE_LINE",
+          "link": 1
+        },
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 14,
+          "shape": 7
+        }
+      ],
+      "outputs": [
+        {
+          "name": "pipe",
+          "type": "PIPE_LINE",
+          "links": [
+            15
+          ],
+          "slot_index": 0,
+          "shape": 3
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "links": [
+            16
+          ],
+          "slot_index": 1,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Fooocus KSampler"
+      },
+      "widgets_values": [
+        "Preview",
+        "ComfyUI"
+      ]
+    },
+    {
+      "id": 3,
+      "type": "Fooocus PreKSampler",
+      "pos": [
+        948,
+        152
+      ],
+      "size": [
+        324.38671875,
+        423.25390625
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "pipe",
+          "type": "PIPE_LINE",
+          "link": 13
+        },
+        {
+          "name": "image_to_latent",
+          "type": "IMAGE",
+          "link": null,
+          "shape": 7
+        },
+        {
+          "name": "latent",
+          "type": "LATENT",
+          "link": null,
+          "shape": 7
+        },
+        {
+          "name": "fooocus_inpaint",
+          "type": "FOOOCUS_INPAINT",
+          "link": null,
+          "shape": 7
+        },
+        {
+          "name": "fooocus_styles",
+          "type": "FOOOCUS_STYLES",
+          "link": 3,
+          "shape": 7
+        }
+      ],
+      "outputs": [
+        {
+          "name": "pipe",
+          "type": "PIPE_LINE",
+          "links": [
+            1
+          ],
+          "slot_index": 0,
+          "shape": 3
+        },
+        {
+          "name": "model",
+          "type": "MODEL",
+          "links": [
+            14
+          ],
+          "slot_index": 1,
+          "shape": 3
+        },
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "links": null,
+          "shape": 3
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "links": null,
+          "shape": 3
+        },
+        {
+          "name": "CONDITIONING+",
+          "type": "CONDITIONING",
+          "links": null,
+          "shape": 3
+        },
+        {
+          "name": "CONDITIONING-",
+          "type": "CONDITIONING",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Fooocus PreKSampler"
+      },
+      "widgets_values": [
+        30,
+        4,
+        "dpmpp_2m_sde_gpu",
+        "karras",
+        148815603431326,
+        "randomize",
+        1,
+        "Simple",
+        2,
+        7,
+        1.5,
+        0.8,
+        0.3,
+        0.25,
+        false
+      ]
+    }
+  ],
+  "links": [
+    [
+      1,
+      3,
+      0,
+      4,
+      0,
+      "PIPE_LINE"
+    ],
+    [
+      3,
+      5,
+      0,
+      3,
+      4,
+      "FOOOCUS_STYLES"
+    ],
+    [
+      12,
+      11,
+      0,
+      12,
+      0,
+      "LORA_STACK"
+    ],
+    [
+      13,
+      12,
+      0,
+      3,
+      0,
+      "PIPE_LINE"
+    ],
+    [
+      14,
+      3,
+      1,
+      4,
+      1,
+      "MODEL"
+    ],
+    [
+      15,
+      4,
+      0,
+      13,
+      0,
+      "PIPE_LINE"
+    ],
+    [
+      16,
+      4,
+      1,
+      13,
+      1,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 1.7985878990921387,
+      "offset": [
+        -974.6751167440711,
+        -22.937556951305623
+      ]
+    },
+    "0246.VERSION": [
+      0,
+      0,
+      4
+    ],
+    "node_versions": {
+      "Fooocus_Nodes": "93063ffddbeef78aef868465087e51dc312112aa"
+    }
+  },
+  "version": 0.4
+}


### PR DESCRIPTION
Based on @Kosinkadink 's suggestions [here](https://github.com/Seedsa/Fooocus_Nodes/issues/47#issuecomment-2568249246), I have changed all instances of `ldm_patched.modules.model_patcher.ModelPatcher` to instead use a new `ldm_patched.modules.model_patcher.FooocusModelPatcher` class which inherits from `comfy.model_patcher.ModelPatcher`.

This seems to fix #47 and fix #48 .

### Overview

- While making these changes, I noted only one functional difference between the original `ldm_patched.modules.model_patcher.ModelPatcher` and the last compatible ComfyUI version `v0.3.6`.
  - This was the commenting out of `# self.model.device = device_to` in the `unpatch_model()` and `load()` methods - seeing as the Fooocus-loaded models don't have a `self.device` attribute which ComfyUI expects. 
- I therefore replicated these same changes in `FooocusModelPatcher`, while keeping the rest of the code identical to `comfy.model_patcher.ModelPatcher` ComfyUI `main`.
- I have tested my changes against all [example workflows.](https://github.com/Seedsa/Fooocus_Nodes/tree/main/workflow)
  - I added an `upscale.json` workflow as well to ensure the workflows cover all nodes within `Fooocus_Nodes`.

@Seedsa do let me know if I have missed anything here.

### Limitations

The way Fooocus_Nodes works is by currently copying modules from an old version of ComfyUI's `comfy/` directory. The fixes in this PR just make the minimal changes required to get `Fooocus_Nodes` running with ComfyUI's `v0.3.10` at the time of writing.

In the future, we should try to use more of an inheritance-style workflow to override specific parts of ComfyUI. This will ensure long term version compatibility between ComfyUI and `Fooocus_Nodes`.